### PR TITLE
Fixed typo in playground related to death-information

### DIFF
--- a/src/pages/Playground.js
+++ b/src/pages/Playground.js
@@ -161,7 +161,7 @@ const Playground = () => {
           setResponse('A list of deaths.');
         } else {
           setResponse(
-            `Information on the deaths deaths caused by ${response[0].name}`
+            `Information on the deaths caused by ${response[0].name}`
           );
         }
       }


### PR DESCRIPTION
A double "deaths" on the response for the death information